### PR TITLE
Refactor shibboleth_idp::metadata::provider to address default source…

### DIFF
--- a/manifests/metadata/provider.pp
+++ b/manifests/metadata/provider.pp
@@ -10,8 +10,13 @@ define shibboleth_idp::metadata::provider (
   $group = undef,
   $mode = '0644',
   $source_path = undef,
-  $source_file = $filename,
+  $source_file = undef,
 ) {
+
+  $_source_file = $source_file ? {
+    undef   => $filename,
+    default => $source_file,
+  }
 
   concat::fragment { "metadata_providers_${id}":
     target  => 'metadata-providers.xml',
@@ -24,7 +29,7 @@ define shibboleth_idp::metadata::provider (
     owner  => $owner,
     group  => $group,
     mode   => $mode,
-    source => "${source_path}/${source_file}",
+    source => "${source_path}/${_source_file}",
   }
 
 }

--- a/spec/defines/metadata_provider_spec.rb
+++ b/spec/defines/metadata_provider_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'shibboleth_idp::metadata::provider', :type => :define do
+  let(:title) { 'TestSP' }
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(:environment => 'test', :root_home => '/root', :service_provider => 'systemd')
+      end
+
+      describe 'file resource with defaults' do
+        let :pre_condition do
+          'class{"shibboleth_idp":
+              shib_install_base => "/junk/path"
+           }'
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        context 'with defaults' do
+          
+          it { should contain_file('/junk/path/metadata/TestSP-metadata.xml').with({
+            :source => "/TestSP-metadata.xml",
+          })}
+
+        end
+
+        context 'with source_path => /file/source' do
+          let(:params) { {:source_path => '/file/source'} }
+
+          it { should contain_file('/junk/path/metadata/TestSP-metadata.xml').with({
+            :source => "/file/source/TestSP-metadata.xml",
+          })}
+
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/metadata_provider_spec.rb
+++ b/spec/defines/metadata_provider_spec.rb
@@ -19,20 +19,23 @@ describe 'shibboleth_idp::metadata::provider', :type => :define do
         it { is_expected.to compile.with_all_deps }
 
         context 'with defaults' do
-          
-          it { should contain_file('/junk/path/metadata/TestSP-metadata.xml').with({
-            :source => "/TestSP-metadata.xml",
-          })}
+
+          it do
+            should contain_file('/junk/path/metadata/TestSP-metadata.xml').with(
+              :source => '/TestSP-metadata.xml'
+            )
+          end
 
         end
 
         context 'with source_path => /file/source' do
-          let(:params) { {:source_path => '/file/source'} }
+          let(:params) { { :source_path => '/file/source' } }
 
-          it { should contain_file('/junk/path/metadata/TestSP-metadata.xml').with({
-            :source => "/file/source/TestSP-metadata.xml",
-          })}
-
+          it do
+            should contain_file('/junk/path/metadata/TestSP-metadata.xml').with(
+              :source => '/file/source/TestSP-metadata.xml'
+            )
+          end
         end
       end
     end

--- a/spec/defines/metadata_provider_spec.rb
+++ b/spec/defines/metadata_provider_spec.rb
@@ -19,13 +19,11 @@ describe 'shibboleth_idp::metadata::provider', :type => :define do
         it { is_expected.to compile.with_all_deps }
 
         context 'with defaults' do
-
           it do
             should contain_file('/junk/path/metadata/TestSP-metadata.xml').with(
               :source => '/TestSP-metadata.xml'
             )
           end
-
         end
 
         context 'with source_path => /file/source' do


### PR DESCRIPTION
… under Puppet 3

Fixes #8 The use of param variables within other param default values does not work in Puppet 3. This change moves the default handling into the class body.