### PR TITLE
Add specific release of shibcas module files for installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 2.1.10
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 2.1.10

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2017-03-16 (0.1.5)  Dirk Tepe
+        * Manage version of Shibcas source files
+
 2017-03-07 (0.1.4)  Dirk Tepe
         * Fix previously broken release
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,8 @@ class shibboleth_idp (
   $jce_policy_src          = $shibboleth_idp::params::jce_policy_src,
 
   $include_cas             = $shibboleth_idp::params::include_cas,
+  $shibcas_version         = $shibboleth_idp::params::shibcas_version,
+  $shibcas_auth_version    = $shibboleth_idp::params::shibcas_auth_version,
   $cas_server_url          = $shibboleth_idp::params::cas_server_url,
 
   $ldap_url                = $shibboleth_idp::params::ldap_url,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,8 @@ class shibboleth_idp::install inherits shibboleth_idp {
 
   $java_home = $shibboleth_idp::java_home
   $include_cas = $shibboleth_idp::include_cas
+  $shibcas_version = $shibboleth_idp::shibcas_version
+  $shibcas_auth_version = $shibboleth_idp::shibcas_auth_version
   $proxy_host = $shibboleth_idp::proxy_host
   $proxy_port = $shibboleth_idp::proxy_port
   $nameid_generators = $shibboleth_idp::nameid_generators
@@ -140,13 +142,13 @@ class shibboleth_idp::install inherits shibboleth_idp {
   # Fetch and install the ShibCAS component.
   if $include_cas {
     archive { '/tmp/master.tar.gz':
-      source       => 'https://github.com/Unicon/shib-cas-authn3/archive/master.tar.gz',
+      source       => "https://github.com/Unicon/shib-cas-authn3/archive/v${shibcas_version}.tar.gz",
       extract      => true,
       extract_path => $shibboleth_idp::shib_src_dir,
       user         => $shibboleth_idp::shib_user,
       group        => $shibboleth_idp::shib_group,
       cleanup      => true,
-      creates      => "${shibboleth_idp::shib_src_dir}/shib-cas-authn3-master/README.md",
+      creates      => "${shibboleth_idp::shib_src_dir}/shib-cas-authn3-${shibcas_version}/README.md",
     } ->
 
     file { "${shibboleth_idp::shib_install_base}/flows/authn/Shibcas":
@@ -155,19 +157,19 @@ class shibboleth_idp::install inherits shibboleth_idp {
       group   => $shibboleth_idp::shib_group,
       mode    => '0644',
       recurse => true,
-      source  => "${shibboleth_idp::shib_src_dir}/shib-cas-authn3-master/IDP_HOME/flows/authn/Shibcas",
+      source  => "${shibboleth_idp::shib_src_dir}/shib-cas-authn3-${shibcas_version}/IDP_HOME/flows/authn/Shibcas",
       require => Exec['shibboleth idp install'],
       notify  => Exec['shibboleth idp build'],
     }
 
     # Use archive to fetch a couple of jar files, but do not extract them.
-    archive { "${shibboleth_idp::shib_install_base}/edit-webapp/WEB-INF/lib/shib-cas-authenticator-3.0.0.jar":
-      source  => 'https://github.com/Unicon/shib-cas-authn3/releases/download/v3.0.0/shib-cas-authenticator-3.0.0.jar',
+    archive { "${shibboleth_idp::shib_install_base}/edit-webapp/WEB-INF/lib/shib-cas-authenticator-${shibcas_auth_version}.jar":
+      source  => "https://github.com/Unicon/shib-cas-authn3/releases/download/v${shibcas_auth_version}/shib-cas-authenticator-${shibcas_auth_version}.jar",
       extract => false,
       cleanup => false,
       user    => $shibboleth_idp::shib_user,
       group   => $shibboleth_idp::shib_group,
-      creates => "${shibboleth_idp::shib_install_base}/edit-webapp/WEB-INF/lib/shib-cas-authenticator-3.0.0.jar",
+      creates => "${shibboleth_idp::shib_install_base}/edit-webapp/WEB-INF/lib/shib-cas-authenticator-${shibcas_auth_version}.jar",
       require => Exec['shibboleth idp install'],
       notify  => Exec['shibboleth idp build'],
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,9 @@ class shibboleth_idp::params {
   $jce_policy_src          = undef
 
   $include_cas             = false
+  # These should really be the same, but we have some sort of compatibility issue
+  $shibcas_version         = '3.1.0'
+  $shibcas_auth_version    = '3.0.0'
   $cas_server_url          = undef
 
   $ldap_url                = undef

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "MiamiOH-shibboleth_idp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": "Dirk Tepe",
   "summary": "Manage Shibboleth IdP",
   "license": "GPL-3.0+",
@@ -31,10 +31,6 @@
     }
   ],
   "requirements": [
-    {
-      "name": "pe",
-      "version_requirement": ">= 3.7.0 < 5.0.0"
-    },
     {
       "name": "puppet",
       "version_requirement": ">= 3.7.0 < 5.0.0"


### PR DESCRIPTION
We’ve run into a compatibility issue between Shib and CAS in the latest Shibcas release. This is likely due to our older version of CAS. This will need a better resolution in the future.