### PR TITLE
Fixes #37 - Remove Concat version constraint

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,7 @@
 fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    concat: 
-      repo: "https://github.com/puppetlabs/puppetlabs-concat.git"
-      ref: "2.2.0"
+    concat: "https://github.com/puppetlabs/puppetlabs-concat.git"
     archive: "https://github.com/voxpupuli/puppet-archive.git"
     openssl: "https://github.com/camptocamp/puppet-openssl.git"
     profiled: "https://github.com/unibet/puppet-profiled.git"

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "tags": ["shibboleth", "shib", "idp"],
   "dependencies": [
     {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.2.0 < 5.0.0"},
-    {"name": "puppetlabs/concat", "version_requirement": ">= 1.1.1 < 2.2.0"},
+    {"name": "puppetlabs/concat", "version_requirement": ">= 1.1.1 < 3.0.0"},
     {"name": "puppet/archive", "version_requirement": ">= 0.5.0 < 2.0.0"},
     {"name": "camptocamp/openssl", "version_requirement": ">= 1.8.2 < 2.0.0"},
     {"name": "unibet/profiled", "version_requirement": ">= 0.1.4 < 1.0.0"},


### PR DESCRIPTION
We need a newer puppet 4 only apache module which requires a newer concat module